### PR TITLE
#162832583 Add JWT authentication to the API endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@
 import json
 
 from flask import Flask, request, jsonify, abort, make_response
+from flask_jwt_extended import JWTManager
 
 from instance.config import APP_CONFIG
 from app.api.v1.models.user_model import UserModel
@@ -12,6 +13,7 @@ from app.api.v1.views.question_view import API
 def create_app(config_name):
     '''Instantiate the Flask application'''
     app = Flask(__name__, instance_relative_config=True)
+    jwt = JWTManager(app)
     app.config.from_object(APP_CONFIG[config_name])
     app.config.from_pyfile('config.py')
     app.register_blueprint(AUTH)

--- a/app/api/v1/views/question_view.py
+++ b/app/api/v1/views/question_view.py
@@ -38,6 +38,7 @@ def user_post_question():
     }), 201)
 
 @API.route('/questions', methods=['GET'])
+@jwt_required
 def user_fetch_all_questions():
     '''API endpoint for fetching all questions'''
     questions = QuestionModel.get_all_questions()
@@ -51,6 +52,7 @@ def user_fetch_all_questions():
     }), 200)
 
 @API.route('/questions/<question_id>', methods=['GET'])
+@jwt_required
 def fetch_one_question(question_id):
     '''API endpoint for fetching one question'''
     if question_id.isdigit():
@@ -68,6 +70,7 @@ def fetch_one_question(question_id):
     }), 400)
 
 @API.route('/questions/<question_id>', methods=['DELETE'])
+@jwt_required
 def delete_one_question(question_id):
     '''API endpoint for deleting one question'''
     if question_id.isdigit():
@@ -86,6 +89,7 @@ def delete_one_question(question_id):
     }), 400)
 
 @API.route('/questions/<question_id>/answers', methods=['POST'])
+@jwt_required
 def post_answer(question_id):
     '''API endpoint for posting an answer'''
     description = request.get_json()['description']
@@ -112,6 +116,7 @@ def post_answer(question_id):
     }), 400)
 
 @API.route('/questions/<question_id>/answers/<answer_id>', methods=['PUT'])
+@jwt_required
 def update_answer(question_id, answer_id):
     '''API endpoint for updating an answer'''
     description = request.get_json()['description']

--- a/app/api/v1/views/question_view.py
+++ b/app/api/v1/views/question_view.py
@@ -1,5 +1,6 @@
 '''This module represents the question view'''
 from flask import Blueprint, request, jsonify, make_response
+from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from app.api.utils.serializer import serialize
 from app.api.v1.models.question_model import QuestionModel, QUESTIONS
@@ -8,6 +9,7 @@ from app.api.v1.models.answer_model import AnswerModel
 API = Blueprint("api", __name__, url_prefix='/api/v1')
 
 @API.route('/questions', methods=['POST'])
+@jwt_required
 def user_post_question():
     '''API endpoint for posting questions'''
     title = request.get_json()['title']

--- a/app/api/v1/views/question_view.py
+++ b/app/api/v1/views/question_view.py
@@ -111,7 +111,7 @@ def post_answer(question_id):
         if asked_by == answered_by:
             return make_response(jsonify({
                 'message': "YOU CAN'T ANSWER YOUR OWN QUESTION"
-            }), 401)
+            }), 403)
 
         AnswerModel.add_answer(answer, question_id)
         return make_response(jsonify({

--- a/app/api/v1/views/question_view.py
+++ b/app/api/v1/views/question_view.py
@@ -14,7 +14,7 @@ def user_post_question():
     '''API endpoint for posting questions'''
     title = request.get_json()['title']
     description = request.get_json()['description']
-    created_by = request.get_json()['created_by']
+    created_by = get_jwt_identity()
 
     question = QuestionModel(
         title=title,
@@ -93,7 +93,7 @@ def delete_one_question(question_id):
 def post_answer(question_id):
     '''API endpoint for posting an answer'''
     description = request.get_json()['description']
-    answered_by = request.get_json()['answered_by']
+    answered_by = get_jwt_identity()
 
     answer = AnswerModel(
         description=description,
@@ -106,6 +106,13 @@ def post_answer(question_id):
             return make_response(jsonify({
                 'message': "QUESTION WITH ID '{}' DOESN'T EXIST!".format(question_id)
             }), 404)
+        asked_by = question['created_by']
+
+        if asked_by == answered_by:
+            return make_response(jsonify({
+                'message': "YOU CAN'T ANSWER YOUR OWN QUESTION"
+            }), 401)
+
         AnswerModel.add_answer(answer, question_id)
         return make_response(jsonify({
             'status': 201,

--- a/app/api/v1/views/user_view.py
+++ b/app/api/v1/views/user_view.py
@@ -29,6 +29,13 @@ def user_registration():
             'message': 'PASSWORD CANNOT BE EMPTY'
         }), 400)
 
+    users = UserModel.get_all_users()
+
+    if next(filter(lambda u: u['username'] == username, users), None):
+        return make_response(jsonify({
+            'message': "A USER WITH USERNAME '{}' ALREADY EXISTS!".format(username)
+        }), 401)
+
     # Create an instance of the user
     user = UserModel(
         username=username,

--- a/app/api/v1/views/user_view.py
+++ b/app/api/v1/views/user_view.py
@@ -1,5 +1,6 @@
 '''This module represents the user view'''
 from flask import Blueprint, request, jsonify, make_response
+from flask_jwt_extended import create_access_token, create_refresh_token
 
 from app.api.utils.serializer import serialize
 from app.api.v1.models.user_model import UserModel
@@ -9,7 +10,6 @@ AUTH = Blueprint("auth", __name__, url_prefix='/auth')
 @AUTH.route('/signup', methods=['POST'])
 def user_registration():
     '''API endpoint for user registration'''
-    # data = request.get_json()
     username = request.get_json()['username']
     email = request.get_json()['email']
     password = request.get_json()['password']
@@ -38,12 +38,17 @@ def user_registration():
 
     UserModel.add_user(serialize(user))
 
+    access_token = create_access_token(identity=username)
+    refresh_token = create_refresh_token(identity=username)
+
     response = make_response(jsonify({
         'status': 201,
         'data': [
             {
                 'id': user.get_user_id(),
-                'message': "Create user record"
+                'message': "Create user record",
+                'access_token': access_token,
+                'refresh_token': refresh_token
             }
         ]
     }), 201)
@@ -64,11 +69,15 @@ def user_login():
         }), 400)
 
     if UserModel.verify_password_hash(password, current_user['password']):
+        access_token = create_access_token(identity=username)
+        refresh_token = create_refresh_token(identity=username)
         return make_response(jsonify({
             'status': 200,
             'data': [
                 {
-                    'message': 'Logged in as {}'.format(username)
+                    'message': 'Logged in as {}'.format(username),
+                    'access_token': access_token,
+                    'refresh_token': refresh_token
                 }
             ]
         }), 200)

--- a/app/tests/v1/test_base.py
+++ b/app/tests/v1/test_base.py
@@ -20,6 +20,12 @@ class BaseTestCase(unittest.TestCase):
         self.user_registration = dict(username="john", email="john@example.com", password="12345")
         self.user_login = dict(username="john", password="12345")
 
+        self.new_user_registration = dict(
+            username="rachael",
+            email="rachael@example.com",
+            password="67890")
+        self.new_user_login = dict(username="rachael", password="67890")
+
         self.empty_username = dict(username="", email="john@example.com", password="12")
         self.digit_username = dict(username="1234", email="john@example.com", password="12")
 
@@ -49,18 +55,18 @@ class BaseTestCase(unittest.TestCase):
         authentication_headers['Authorization'] = "Bearer {}".format(access_token)
         return authentication_headers
 
-    def get_response_from_user(self):
+    def get_response_from_user(self, user_registration, user_login):
         '''Return the response from a user login'''
         res = self.client().post(
             '/auth/signup',
             headers=self.get_accept_content_type_headers(),
-            data=json.dumps(self.user_registration)
+            data=json.dumps(user_registration)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().post(
             '/auth/login',
             headers=self.get_accept_content_type_headers(),
-            data=json.dumps(self.user_login)
+            data=json.dumps(user_login)
         )
         self.assertEqual(res.status_code, 200)
         return res

--- a/app/tests/v1/test_base.py
+++ b/app/tests/v1/test_base.py
@@ -1,4 +1,5 @@
 '''This module represents the base test class'''
+import json
 import unittest
 
 from datetime import datetime
@@ -35,13 +36,40 @@ class BaseTestCase(unittest.TestCase):
 
         self.answer = dict(description="Test answer description", answered_by="A_author")
 
-    @staticmethod
-    def get_accept_content_type_headers():
+    def get_accept_content_type_headers(self):
         '''Return the content type headers for the body'''
         return {
             'Accept': 'application/json',
             'Content-Type': 'application/json'
         }
+
+    def get_authentication_headers(self, access_token):
+        '''Return the authentication header by providing the authorization field'''
+        authentication_headers = self.get_accept_content_type_headers()
+        authentication_headers['Authorization'] = "Bearer {}".format(access_token)
+        return authentication_headers
+
+    def get_response_from_user(self):
+        '''Return the response from a user login'''
+        res = self.client().post(
+            '/auth/signup',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(self.user_registration)
+        )
+        self.assertEqual(res.status_code, 201)
+        res = self.client().post(
+            '/auth/login',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(self.user_login)
+        )
+        self.assertEqual(res.status_code, 200)
+        return res
+
+    def get_access_token(self):
+        '''Return the access token after user login'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        return response_msg["data"][0]["access_token"]
 
     def test_serialize_function(self):
         '''Test the function serialize() converts an object to a dictionary'''

--- a/app/tests/v1/test_base.py
+++ b/app/tests/v1/test_base.py
@@ -65,12 +65,6 @@ class BaseTestCase(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         return res
 
-    def get_access_token(self):
-        '''Return the access token after user login'''
-        res = self.get_response_from_user()
-        response_msg = json.loads(res.data.decode("UTF-8"))
-        return response_msg["data"][0]["access_token"]
-
     def test_serialize_function(self):
         '''Test the function serialize() converts an object to a dictionary'''
         user = UserModel(username="Test", email="test@example.com", password="12345")

--- a/app/tests/v1/test_base.py
+++ b/app/tests/v1/test_base.py
@@ -71,6 +71,19 @@ class BaseTestCase(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         return res
 
+    def get_response_from_editing_answer(self, url, access_token):
+        '''Return the response from editing an answer'''
+        res = self.client().put(
+            url,
+            headers=self.get_authentication_headers(access_token),
+            data=json.dumps({
+                'description': "Updated test answer description",
+                'accepted': True,
+                "rejected": False
+            })
+        )
+        return res
+
     def test_serialize_function(self):
         '''Test the function serialize() converts an object to a dictionary'''
         user = UserModel(username="Test", email="test@example.com", password="12345")

--- a/app/tests/v1/test_question.py
+++ b/app/tests/v1/test_question.py
@@ -168,7 +168,7 @@ class QuestionTestCase(BaseTestCase):
             data=json.dumps(self.answer)
         )
         response_msg = json.loads(res.data.decode("UTF-8"))
-        self.assertEqual(res.status_code, 401)
+        self.assertEqual(res.status_code, 403)
         self.assertEqual(response_msg["message"], "YOU CAN'T ANSWER YOUR OWN QUESTION")
 
     def test_answer_non_existent_question(self):

--- a/app/tests/v1/test_question.py
+++ b/app/tests/v1/test_question.py
@@ -7,9 +7,12 @@ class QuestionTestCase(BaseTestCase):
     '''Test definitions for a question'''
     def test_user_post_question(self):
         '''Test the API can post questions'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().post(
             '/api/v1/questions',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
@@ -19,15 +22,18 @@ class QuestionTestCase(BaseTestCase):
 
     def test_fetch_all_questions(self):
         '''Test the API can fetch all questions'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().post(
             '/api/v1/questions',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().get(
             '/api/v1/questions',
-            headers=self.get_authentication_headers(self.get_access_token())
+            headers=self.get_authentication_headers(access_token)
         )
         self.assertEqual(res.status_code, 200)
         response_msg = json.loads(res.data.decode("UTF-8"))
@@ -39,9 +45,12 @@ class QuestionTestCase(BaseTestCase):
         Test the API returns formatted message when trying to
         fetch questions from an empty record
         '''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().get(
             '/api/v1/questions',
-            headers=self.get_authentication_headers(self.get_access_token())
+            headers=self.get_authentication_headers(access_token)
         )
         self.assertEqual(res.status_code, 404)
         response_msg = json.loads(res.data.decode("UTF-8"))
@@ -49,15 +58,18 @@ class QuestionTestCase(BaseTestCase):
 
     def test_fetch_one_question(self):
         '''Test the API can fetch one question'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().post(
             '/api/v1/questions',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().get(
             '/api/v1/questions/1',
-            headers=self.get_authentication_headers(self.get_access_token())
+            headers=self.get_authentication_headers(access_token)
         )
         self.assertEqual(res.status_code, 200)
         response_msg = json.loads(res.data.decode("UTF-8"))
@@ -66,9 +78,12 @@ class QuestionTestCase(BaseTestCase):
 
     def test_incorrect_question_id(self):
         '''Test the API cannot fetch a question with an incorrect id'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().get(
             '/api/v1/questions/i',
-            headers=self.get_authentication_headers(self.get_access_token())
+            headers=self.get_authentication_headers(access_token)
         )
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 400)
@@ -76,9 +91,12 @@ class QuestionTestCase(BaseTestCase):
 
     def test_non_existent_question(self):
         '''Test the API cannot a non-existent question'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().get(
             '/api/v1/questions/2',
-            headers=self.get_authentication_headers(self.get_access_token())
+            headers=self.get_authentication_headers(access_token)
         )
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 404)
@@ -86,15 +104,18 @@ class QuestionTestCase(BaseTestCase):
 
     def test_delete_one_question(self):
         '''Test the API can delete one question'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().post(
             '/api/v1/questions',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().delete(
             '/api/v1/questions/1',
-            headers=self.get_authentication_headers(self.get_access_token())
+            headers=self.get_authentication_headers(access_token)
         )
         self.assertEqual(res.status_code, 200)
         response_msg = json.loads(res.data.decode("UTF-8"))
@@ -106,15 +127,18 @@ class QuestionTestCase(BaseTestCase):
 
     def test_post_answer(self):
         '''Test the API can post an answer'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().post(
             '/api/v1/questions',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().post(
             '/api/v1/questions/1/answers',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.answer)
         )
         response_msg = json.loads(res.data.decode("UTF-8"))
@@ -123,9 +147,12 @@ class QuestionTestCase(BaseTestCase):
 
     def test_answer_non_existent_question(self):
         '''Test the API cannot post an answer to a non-existing question'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().post(
             '/api/v1/questions/1/answers',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.answer)
         )
         response_msg = json.loads(res.data.decode("UTF-8"))
@@ -137,21 +164,24 @@ class QuestionTestCase(BaseTestCase):
 
     def test_edit_answer(self):
         '''Test the API can edit an answer'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().post(
             '/api/v1/questions',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().post(
             '/api/v1/questions/1/answers',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.answer)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().put(
             '/api/v1/questions/1/answers/1',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps({
                 'description': "Updated test answer description",
                 'accepted': True,
@@ -164,15 +194,18 @@ class QuestionTestCase(BaseTestCase):
 
     def test_edit_non_existent_answer(self):
         '''Test the API cannot edit a non-existent answer'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().post(
             '/api/v1/questions',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().put(
             '/api/v1/questions/1/answers/1',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps({
                 'description': 'Non-existent answer',
                 'accepted': False,
@@ -185,15 +218,18 @@ class QuestionTestCase(BaseTestCase):
 
     def test_incorrect_edit_answer(self):
         '''Test the API cannot edit an answer with an incorrect ID'''
+        res = self.get_response_from_user()
+        response_msg = json.loads(res.data.decode("UTF-8"))
+        access_token = response_msg["data"][0]["access_token"]
         res = self.client().post(
             '/api/v1/questions',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().put(
             '/api/v1/questions/1/answers/i',
-            headers=self.get_authentication_headers(self.get_access_token()),
+            headers=self.get_authentication_headers(access_token),
             data=json.dumps({
                 'description': 'Incorrect answer ID',
                 'accepted': False,

--- a/app/tests/v1/test_question.py
+++ b/app/tests/v1/test_question.py
@@ -9,7 +9,7 @@ class QuestionTestCase(BaseTestCase):
         '''Test the API can post questions'''
         res = self.client().post(
             '/api/v1/questions',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
@@ -21,11 +21,14 @@ class QuestionTestCase(BaseTestCase):
         '''Test the API can fetch all questions'''
         res = self.client().post(
             '/api/v1/questions',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
-        res = self.client().get('/api/v1/questions')
+        res = self.client().get(
+            '/api/v1/questions',
+            headers=self.get_authentication_headers(self.get_access_token())
+        )
         self.assertEqual(res.status_code, 200)
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(200, response_msg["status"])
@@ -36,7 +39,10 @@ class QuestionTestCase(BaseTestCase):
         Test the API returns formatted message when trying to
         fetch questions from an empty record
         '''
-        res = self.client().get('/api/v1/questions')
+        res = self.client().get(
+            '/api/v1/questions',
+            headers=self.get_authentication_headers(self.get_access_token())
+        )
         self.assertEqual(res.status_code, 404)
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual("NO QUESTION HAS BEEN ADDED YET!", response_msg["message"])
@@ -45,11 +51,14 @@ class QuestionTestCase(BaseTestCase):
         '''Test the API can fetch one question'''
         res = self.client().post(
             '/api/v1/questions',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
-        res = self.client().get('/api/v1/questions/1')
+        res = self.client().get(
+            '/api/v1/questions/1',
+            headers=self.get_authentication_headers(self.get_access_token())
+        )
         self.assertEqual(res.status_code, 200)
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(200, response_msg["status"])
@@ -57,14 +66,20 @@ class QuestionTestCase(BaseTestCase):
 
     def test_incorrect_question_id(self):
         '''Test the API cannot fetch a question with an incorrect id'''
-        res = self.client().get('/api/v1/questions/i')
+        res = self.client().get(
+            '/api/v1/questions/i',
+            headers=self.get_authentication_headers(self.get_access_token())
+        )
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 400)
         self.assertEqual("QUESTION ID MUST BE AN INTEGER VALUE", response_msg["message"])
 
     def test_non_existent_question(self):
         '''Test the API cannot a non-existent question'''
-        res = self.client().get('/api/v1/questions/2')
+        res = self.client().get(
+            '/api/v1/questions/2',
+            headers=self.get_authentication_headers(self.get_access_token())
+        )
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(res.status_code, 404)
         self.assertEqual("QUESTION WITH ID '2' DOESN'T EXIST!", response_msg["message"])
@@ -73,11 +88,14 @@ class QuestionTestCase(BaseTestCase):
         '''Test the API can delete one question'''
         res = self.client().post(
             '/api/v1/questions',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
-        res = self.client().delete('/api/v1/questions/1')
+        res = self.client().delete(
+            '/api/v1/questions/1',
+            headers=self.get_authentication_headers(self.get_access_token())
+        )
         self.assertEqual(res.status_code, 200)
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual(response_msg["status"], 200)
@@ -90,13 +108,13 @@ class QuestionTestCase(BaseTestCase):
         '''Test the API can post an answer'''
         res = self.client().post(
             '/api/v1/questions',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().post(
             '/api/v1/questions/1/answers',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.answer)
         )
         response_msg = json.loads(res.data.decode("UTF-8"))
@@ -107,7 +125,7 @@ class QuestionTestCase(BaseTestCase):
         '''Test the API cannot post an answer to a non-existing question'''
         res = self.client().post(
             '/api/v1/questions/1/answers',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.answer)
         )
         response_msg = json.loads(res.data.decode("UTF-8"))
@@ -121,19 +139,19 @@ class QuestionTestCase(BaseTestCase):
         '''Test the API can edit an answer'''
         res = self.client().post(
             '/api/v1/questions',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().post(
             '/api/v1/questions/1/answers',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.answer)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().put(
             '/api/v1/questions/1/answers/1',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps({
                 'description': "Updated test answer description",
                 'accepted': True,
@@ -148,13 +166,13 @@ class QuestionTestCase(BaseTestCase):
         '''Test the API cannot edit a non-existent answer'''
         res = self.client().post(
             '/api/v1/questions',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().put(
             '/api/v1/questions/1/answers/1',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps({
                 'description': 'Non-existent answer',
                 'accepted': False,
@@ -169,13 +187,13 @@ class QuestionTestCase(BaseTestCase):
         '''Test the API cannot edit an answer with an incorrect ID'''
         res = self.client().post(
             '/api/v1/questions',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps(self.question)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().put(
             '/api/v1/questions/1/answers/i',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_authentication_headers(self.get_access_token()),
             data=json.dumps({
                 'description': 'Incorrect answer ID',
                 'accepted': False,

--- a/app/tests/v1/test_user.py
+++ b/app/tests/v1/test_user.py
@@ -1,6 +1,7 @@
 '''This module represents tests for the user entity'''
 import json
 
+from app.api.v1.models.user_model import USERS, UserModel
 from app.tests.v1.test_base import BaseTestCase
 
 class UserTestCase(BaseTestCase):
@@ -99,3 +100,12 @@ class UserTestCase(BaseTestCase):
         self.assertEqual(res.status_code, 401)
         response_msg = json.loads(res.data.decode("UTF-8"))
         self.assertEqual('WRONG CREDENTIALS!', response_msg["message"])
+
+    def test_get_user_by_id(self):
+        '''Test the method fetch a user by user id returns the correct user'''
+        self.client().post(
+            '/auth/signup',
+            headers=self.get_accept_content_type_headers(),
+            data=json.dumps(self.user_registration)
+        )
+        self.assertEqual(UserModel.get_user_by_id(1), USERS[0])

--- a/app/tests/v1/test_user.py
+++ b/app/tests/v1/test_user.py
@@ -9,7 +9,7 @@ class UserTestCase(BaseTestCase):
         '''Test the API can register a user'''
         res = self.client().post(
             '/auth/signup',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_accept_content_type_headers(),
             data=json.dumps(self.user_registration)
         )
         self.assertEqual(res.status_code, 201)
@@ -21,13 +21,13 @@ class UserTestCase(BaseTestCase):
         '''Test the API can log in a user'''
         res = self.client().post(
             '/auth/signup',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_accept_content_type_headers(),
             data=json.dumps(self.user_registration)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().post(
             '/auth/login',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_accept_content_type_headers(),
             data=json.dumps(self.user_login)
         )
         self.assertEqual(res.status_code, 200)
@@ -39,7 +39,7 @@ class UserTestCase(BaseTestCase):
         '''Test the API cannot register a user with an empty username'''
         res = self.client().post(
             '/auth/signup',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_accept_content_type_headers(),
             data=json.dumps(self.empty_username)
         )
         self.assertEqual(res.status_code, 400)
@@ -52,7 +52,7 @@ class UserTestCase(BaseTestCase):
         '''
         res = self.client().post(
             '/auth/signup',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_accept_content_type_headers(),
             data=json.dumps(self.digit_username)
         )
         self.assertEqual(res.status_code, 400)
@@ -65,7 +65,7 @@ class UserTestCase(BaseTestCase):
         '''
         res = self.client().post(
             '/auth/signup',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_accept_content_type_headers(),
             data=json.dumps(self.empty_password)
         )
         self.assertEqual(res.status_code, 400)
@@ -76,7 +76,7 @@ class UserTestCase(BaseTestCase):
         '''Test the API cannot log in a user who is not yet registered'''
         res = self.client().post(
             '/auth/login',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_accept_content_type_headers(),
             data=json.dumps(self.incorrect_username)
         )
         self.assertEqual(res.status_code, 400)
@@ -87,13 +87,13 @@ class UserTestCase(BaseTestCase):
         '''Test the API cannot log in a user with an incorrect password'''
         res = self.client().post(
             '/auth/signup',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_accept_content_type_headers(),
             data=json.dumps(self.user_registration)
         )
         self.assertEqual(res.status_code, 201)
         res = self.client().post(
             '/auth/login',
-            headers=BaseTestCase.get_accept_content_type_headers(),
+            headers=self.get_accept_content_type_headers(),
             data=json.dumps(self.incorrect_password)
         )
         self.assertEqual(res.status_code, 401)

--- a/instance/config.py
+++ b/instance/config.py
@@ -5,6 +5,7 @@ class Config(object):
     """Parent configuration class"""
     DEBUG = False
     SECRET = os.getenv('SECRET_KEY')
+    JWT_SECRET_KEY = os.getenv('JWT_SECRET_KEY')
 
 class DevelopmentConfig(Config):
     """Development environment configurations"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ attrs==18.2.0
 Click==7.0
 coverage==4.5.2
 Flask==1.0.2
+Flask-JWT-Extended==3.14.0
 isort==4.3.4
 itsdangerous==1.1.0
 Jinja2==2.10
@@ -16,6 +17,7 @@ passlib==1.7.1
 pathlib2==2.3.3
 pluggy==0.8.0
 py==1.7.0
+PyJWT==1.7.1
 pylint==2.2.2
 six==1.12.0
 typed-ast==1.1.0


### PR DESCRIPTION
#### What does this PR do?
Secure the API endpoints using JWT

#### Description of Task to be completed?
- Test JWT authentication of the API endpoints
- Implement the logic for securing the API endpoints using JWT

#### How should this be manually tested?
1. Clone the repository and **cd** into it 
2. Create a virtual environment by executing the command `python3 -m venv venv` on the terminal
3. Install the Python packages for the project by executing the command `pip3 install -r requirements.txt`
4. Execute the command `flask run` on the terminal.
5. Using Postman test the API endpoints listed on the [README.md file](https://github.com/khwilo/stackoverflow-lite-api/blob/develop/README.md).
    - For user `/auth/signup` and `/auth/login` using the header:
        1. *key* - **Content-Type** 
        2. *value* - **application/json**
    - For other endpoints use the above content type header together with the authorization header:
        1. *key* - **Authorization**
        2. *value* - **Bearer** <access_token>
  
#### What are the relevant pivotal tracker stories?
#162832583

#### Screenshots
1. Access token and refresh token from user login:
![access_refresh_tokens](https://user-images.githubusercontent.com/5740429/50406033-c4ec7900-07ce-11e9-80f2-66eee9430c03.png)
2. Example header content:
![headers](https://user-images.githubusercontent.com/5740429/50406063-48a66580-07cf-11e9-8c77-1ec31c8d9168.png)
